### PR TITLE
Rebase on master before pushing citation update

### DIFF
--- a/.github/workflows/scholar.yml
+++ b/.github/workflows/scholar.yml
@@ -74,5 +74,6 @@ jobs:
           else
             git add _data/scholar.yml
             git commit -m "Update Google Scholar citation count"
+            git pull --rebase origin master
             git push
           fi


### PR DESCRIPTION
The daily scholar job commits and pushes without pulling. If any commit lands on master between runs (PR merge, manual edit, ImgBot), the push is rejected and citation updates silently stop. Pull --rebase first.