### PR TITLE
Remove dead jQuery load and read-more script from homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -995,15 +995,6 @@ I got my Bachelor's at [IIT Roorkee][31]. On the side, I've built [aideadlin.es]
     </div>
 </div>
 
-<script src="/js/jquery.min.js"></script>
-<script type="text/javascript">
-    $('ul:gt(0) li:gt(12)').hide();
-    $('#read-more-button > a').click(function() {
-        $('ul:gt(0) li:gt(12)').show();
-        $('#read-more-button').hide();
-    });
-</script>
-
 ---
 
 [1]: //mlp.cc.gatech.edu


### PR DESCRIPTION
The News list and #read-more-button were wrapped in {% comment %} (index.md:7-52), so this script has no targets and does nothing. It still loads jQuery 1.9.1 (2013, known XSS CVEs) on every homepage visit. Drop the dead script and the jQuery load.