### PR TITLE
Remove dead Google+/Twitter/FB/Disqus share widgets from post layout

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,9 +2,6 @@
 layout: default
 ---
 
-<script type="text/javascript" src="https://apis.google.com/js/plusone.js"></script>
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-
 <article class="post">
     <div class="row">
         <div class="col-xs-12">
@@ -22,22 +19,6 @@ layout: default
     <div class="when">{{ page.date | date: "%d %B %Y" }}</div>
     <div class='share'>
         <iframe src="https://ghbtns.com/github-btn.html?user=abhshkdz&type=follow&count=true" frameborder="0" scrolling="0" width="170px" height="20px" style="margin-right:20px;"></iframe>
-        <span class='gplus-wrapper'><div class='g-plusone' data-href='{{site.url}}{{page.url}}' data-size='medium'></div></span>
-        <a href="https://twitter.com/share" class="twitter-share-button" data-url="{{site.url}}{{page.url}}" data-text="{{page.title}}" data-via="abhshkdz"></a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-        <iframe allowTransparency='true' frameborder='0' scrolling='no' src='https://www.facebook.com/plugins/like.php?href={{site.url}}{{page.url}}&layout=button_count&show_faces=false&width=77&action=like&colorscheme=light&height=20' style='margin-left: 30px; border:none; overflow:hidden; width:100px; height:20px;'></iframe>
     </div>
     <hr>
-    <div id="disqus_thread"></div>
-    <script type="text/javascript">
-        /* * * CONFIGURATION VARIABLES * * */
-        var disqus_shortname = 'abhshkdz';
-
-        /* * * DON'T EDIT BELOW THIS LINE * * */
-        (function() {
-            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-    </script>
-    <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
 </article>


### PR DESCRIPTION
post.html shipped stale integrations: Google+ (shut down 2019, plusone.js), a Twitter share button loaded via two redundant widget snippets, a Facebook like iframe with an unencoded href, and a Disqus embed. None of these render anything meaningful anymore. Drop them; keep the GitHub follow iframe.