### PR TITLE
Move gtag script inside <head>

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -101,16 +101,16 @@
         }
         </script>
         {% endif %}
-    </head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VY0W5MQJ9Y"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-VY0W5MQJ9Y"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
 
-        gtag('config', 'G-VY0W5MQJ9Y');
-    </script>
+            gtag('config', 'G-VY0W5MQJ9Y');
+        </script>
+    </head>
     <body>
         <div class="layout">
             <aside class="sidebar">


### PR DESCRIPTION
The Google Analytics snippet sat between </head> and <body>, which is invalid HTML (content not allowed there). Browsers tolerate it, but move it inside <head> where it belongs.