### PR TITLE
Fix sitemap: drop redirecting /about/, add /art/tatters

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://abhishekdas.com/</loc></url>
-  <url><loc>https://abhishekdas.com/about/</loc></url>
   <url><loc>https://abhishekdas.com/art/</loc></url>
+  <url><loc>https://abhishekdas.com/art/tatters</loc></url>
   <url><loc>https://abhishekdas.com/bookshelf/</loc></url>
   <url><loc>https://abhishekdas.com/archive/</loc></url>
 </urlset>


### PR DESCRIPTION
/about/ is a JS redirect to / (no real content), so it shouldn't be in the sitemap. /art/tatters is a real page (permalink in _pages/tatters.md) but was missing from the sitemap.