### PR TITLE
Fix about.md redirect link target

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -4,7 +4,7 @@ title:      About
 permalink:  /about/
 ---
 
-Redirecting to [abhishekdas.com](//abhishekdas.com).
+Redirecting to [abhishekdas.com](/).
 
 <script type="text/javascript">
     location.href='/';


### PR DESCRIPTION
The body text said 'Redirecting to abhishekdas.com' but the markdown link pointed at //abhishekdas.com (self-referential on the same domain), while the JS redirect goes to '/'. Point the link at '/' to match the script.