### PR TITLE
Add trailing slash to /art/tatters permalink

### DIFF
--- a/_pages/tatters.md
+++ b/_pages/tatters.md
@@ -1,7 +1,7 @@
 ---
 layout:     art
 title:      Tatters
-permalink:  /art/tatters
+permalink:  /art/tatters/
 ---
 
 <html lang="en">


### PR DESCRIPTION
Every other page uses a trailing slash in its permalink (/art/, /bookshelf/, /archive/). /art/tatters was the only one without. Add it for consistency. Also update sitemap in the sibling PR to match.