### PR TITLE
Fix implicit global i in tatters draw() loop

### DIFF
--- a/js/tatters/main.js
+++ b/js/tatters/main.js
@@ -105,7 +105,7 @@ function setup() {
 
 function draw() {
     let done = true;
-    for (i = 0; i < strokes_per_frame; i++) {
+    for (let i = 0; i < strokes_per_frame; i++) {
         for (let i = 0; i < blocks.length; i++) {
             if (!blocks[i].isDone()) {
                 blocks[i].addStroke();


### PR DESCRIPTION
The outer loop in draw() used for (i = 0; ...) without let, leaking an implicit global. The inner loop already declares let i, shadowing it correctly, but the outer leak is a strict-mode violation. Add let.